### PR TITLE
Исправление ошибки в виджете FileWidget

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # digitalwand.admin_helper
 API для сборки кастомных админок в Битриксе
 
-Документацию по модулю лучше пока смотреть по комментариям в коде модуля. 
+Документация по модулю доступна по адресу [http://api.digitalwand.ru/admin_helper/](http://api.digitalwand.ru/admin_helper/). Её же можно прочитать в комментариях в коде модуля. 
 
 Есть хорошая вводная статья в блоге: [Генератор админок «Битрикса»](http://samokhvalov.info/blog/all/bitrix-admin-helper/).
 


### PR DESCRIPTION
Если у виджета включить "флаг" REQUIRED, то не удаётся сохранить значение поля, т.к. всё время возникает ошибка типа: "Обязательное поле "#NAME#" не заполнено".
Т.к. проверка наличия значения вызывается раньше чем сохраняется сам файл и его id записывается в поле (метод $this->saveFile()).
Поправил данную ошибку.